### PR TITLE
GraphQL API 전용 전역 예외 처리 모듈을 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ dependencies {
 - Extendable global exception handlers
 - Singleton `EmptyResponse` for null-free design
 - `ObjectsUtil` for null/ID validation
+- `GraphQL Global Exception Handling` via a DataFetcherExceptionResolver implementation that produces consistent error payloads in errors.extensions
 
 ---
 
@@ -80,6 +81,9 @@ com.github.hyeonjaez.springcommon
 │   ├── ErrorCode.java
 │   └── CommonErrorCode.java
 │
+├── graphql           # GraphQL integration
+│   ├── AbstractGraphQLExceptionResolver.java
+│   └── GraphQLExceptionResolver.java
 ├── handler           # Global exception handlers
 │   ├── GlobalExceptionHandler.java
 │   ├── AbstractGlobalExceptionHandler.java
@@ -154,6 +158,40 @@ if (user == null) {
   "message": "User not found"
 }
 ```
+### 4. GraphQL Global Exception Handling
+Any BusinessException or common framework exception thrown in a `@QueryMapping` or `@MutationMapping` will be converted into a GraphQL error with standardized extensions.
+
+### Example Resolver:
+```java
+@QueryMapping
+public UserDto getUserById(@Argument Long id) {
+    UserDto user = userService.findById(id);
+    if (user == null) {
+        throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+    }
+    return user;
+}
+```
+
+### ❌ Sample Error Response
+```json
+{
+  "errors": [
+    {
+      "message": "User not found",
+      "extensions": {
+        "status": "FAILURE",
+        "statusCode": 404,
+        "errorCode": "USER-001"
+      }
+    }
+  ],
+  "data": {
+    "getUserById": null
+  }
+}
+```
+Errors are always returned with HTTP 200, and clients should inspect errors[*].extensions.errorCode or statusCode to handle failures.
 
 ---
 
@@ -162,6 +200,7 @@ if (user == null) {
 - All classes are unit-tested (e.g., `ApiResponseTest`, `ErrorResponseTest`, etc.)
 - Compatible with Java 17 (partial support for Java 11)
 - Spring Boot 3.2 tested
+- Tested with Spring for GraphQL 1.1+
 
 ---
 
@@ -179,6 +218,7 @@ if (user == null) {
 - Spring Boot 3.2+
 - Jakarta Validation
 - JUnit 5
+- Spring for GraphQL 1.1+
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
+    // add Spring boot graphql dependency
+    implementation 'org.springframework.boot:spring-boot-starter-graphql'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
-    // add Spring boot graphql dependency
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
@@ -1,0 +1,152 @@
+package com.github.hyeonjaez.springcommon.graphql;
+
+import com.github.hyeonjaez.springcommon.exception.BusinessException;
+import com.github.hyeonjaez.springcommon.response.ApiStatus;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.schema.DataFetchingEnvironment;
+import org.springframework.graphql.execution.DataFetcherExceptionResolver;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An abstract base class for resolving exceptions that occur during GraphQL data fetching.
+ *
+ * <p>This class implements the {@link DataFetcherExceptionResolver} interface and provides
+ * a mechanism to handle various types of exceptions commonly encountered in GraphQL data fetching
+ * by mapping them to corresponding {@link GraphQLError} objects.
+ *
+ * <p>Subclasses can extend this class to inherit the default exception handling logic or
+ * override specific methods to customize behavior for handling exceptions.
+ *
+ * <p>The {@code resolveException} method processes the exception, identifies its type, and
+ * delegates the handling to the respective handler method. This ensures consistent error
+ * responses for different types of application and server-level exceptions.
+ *
+ * @author hansnam1105
+ * @see com.github.hyeonjaez.springcommon.handler.GlobalExceptionHandler
+ * @see com.github.hyeonjaez.springcommon.handler.ErrorResponse
+ * @see com.github.hyeonjaez.springcommon.exception.BusinessException
+ * @since 0.0.1
+ */
+// AbstractGraphQLExceptionResolver.java
+public abstract class AbstractGraphQLExceptionResolver
+        implements DataFetcherExceptionResolver {
+
+    @Override
+    public Mono<List<GraphQLError>> resolveException(Throwable ex, DataFetchingEnvironment env) {
+        // 1. 비즈니스 예외
+        if (ex instanceof BusinessException) {
+            return Mono.just(List.of(handleBusinessException((BusinessException) ex, env)));
+        }
+        // 2. 리소스 미발견
+        if (ex instanceof NoResourceFoundException noResourceFoundException) {
+            return Mono.just(List.of(handleNoResourceFound(noResourceFoundException, env)));
+        }
+        // 3. HTTP 메서드 지원 안 함
+        if (ex instanceof HttpRequestMethodNotSupportedException httpRequestMethodNotSupportedException) {
+            return Mono.just(List.of(handleMethodNotSupported(httpRequestMethodNotSupportedException, env)));
+        }
+        // 4. 검증 실패
+        if (ex instanceof MethodArgumentNotValidException methodArgumentNotValidException) {
+            return Mono.just(List.of(handleValidationException(methodArgumentNotValidException, env)));
+        }
+        // 5. 메시지 컨버팅 실패 (JSON 파싱 오류 등)
+        if (ex instanceof HttpMessageNotReadableException httpMessageNotReadableException) {
+            return Mono.just(List.of(handleMessageNotReadable(httpMessageNotReadableException, env)));
+        }
+        // 6. 그 외 예외 (Internal Server Error)
+        return Mono.just(List.of(handleGenericException(ex, env)));
+    }
+
+    // --- Handlers for each exception type ---
+    private static final String STATUS = "status";
+    private static final String STATUS_CODE = "statusCode";
+    private static final String ERROR_CODE = "errorCode";
+
+    protected GraphQLError handleBusinessException(BusinessException ex, DataFetchingEnvironment env) {
+        var code = ex.getErrorCode();
+        return GraphqlErrorBuilder.newError(env)
+                .message(code.getMessage())
+                .errorType(ErrorType.DataFetchingException)
+                .extensions(Map.of(
+                        STATUS, ApiStatus.FAILURE,
+                        STATUS_CODE, code.getHttpStatus().value(),
+                        ERROR_CODE, code.getCode()
+                ))
+                .build();
+    }
+
+    protected GraphQLError handleNoResourceFound(NoResourceFoundException ex, DataFetchingEnvironment env) {
+        // 예: 404 Not Found
+        return GraphqlErrorBuilder.newError(env)
+                .message(ex.getMessage())
+                .errorType(ErrorType.DataFetchingException)
+                .extensions(Map.of(
+                        STATUS, ApiStatus.FAILURE,
+                        STATUS_CODE, 404,
+                        ERROR_CODE, "RESOURCE_NOT_FOUND"
+                ))
+                .build();
+    }
+
+    protected GraphQLError handleMethodNotSupported(HttpRequestMethodNotSupportedException ex, DataFetchingEnvironment env) {
+        return GraphqlErrorBuilder.newError(env)
+                .message("지원하지 않는 HTTP 메서드입니다: " + ex.getMethod())
+                .errorType(ErrorType.DataFetchingException)
+                .extensions(Map.of(
+                        STATUS, ApiStatus.FAILURE,
+                        STATUS_CODE, 405,
+                        ERROR_CODE, "METHOD_NOT_ALLOWED"
+                ))
+                .build();
+    }
+
+    protected GraphQLError handleValidationException(MethodArgumentNotValidException ex, DataFetchingEnvironment env) {
+        // 첫 번째 필드 오류 메시지만 예시로 사용
+        var fieldError = ex.getBindingResult().getFieldErrors().get(0);
+        return GraphqlErrorBuilder.newError(env)
+                .message(fieldError.getDefaultMessage())
+                .errorType(ErrorType.ValidationError)
+                .extensions(Map.of(
+                        STATUS, ApiStatus.FAILURE,
+                        STATUS_CODE, 400,
+                        ERROR_CODE, "INVALID_ARGUMENT",
+                        "field", fieldError.getField()
+                ))
+                .build();
+    }
+
+    @SuppressWarnings("unused")
+    protected GraphQLError handleMessageNotReadable(HttpMessageNotReadableException ex, DataFetchingEnvironment env) {
+        return GraphqlErrorBuilder.newError(env)
+                .message("잘못된 요청 메시지 형식입니다.")
+                .errorType(ErrorType.DataFetchingException)
+                .extensions(Map.of(
+                        STATUS, ApiStatus.FAILURE,
+                        STATUS_CODE, 400,
+                        ERROR_CODE, "MESSAGE_NOT_READABLE"
+                ))
+                .build();
+    }
+
+    @SuppressWarnings("unused")
+    protected GraphQLError handleGenericException(Throwable ex, DataFetchingEnvironment env) {
+        return GraphqlErrorBuilder.newError(env)
+                .message("Internal server error")
+                .errorType(ErrorType.DataFetchingException)
+                .extensions(Map.of(
+                        STATUS, ApiStatus.FAILURE,
+                        STATUS_CODE, 500,
+                        ERROR_CODE, "INTERNAL_ERROR"
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
@@ -31,15 +31,32 @@ import java.util.Map;
  * responses for different types of application and server-level exceptions.
  *
  * @author hansnam1105
- * @see com.github.hyeonjaez.springcommon.handler.GlobalExceptionHandler
- * @see com.github.hyeonjaez.springcommon.handler.ErrorResponse
- * @see com.github.hyeonjaez.springcommon.exception.BusinessException
+ * @see com.github.hyeonjaez.springcommon.graphql.GraphQLExceptionResolver
  * @since 0.0.1
  */
 // AbstractGraphQLExceptionResolver.java
 public abstract class AbstractGraphQLExceptionResolver
         implements DataFetcherExceptionResolver {
 
+    /**
+     * Resolves exceptions occurring during the GraphQL data fetching process and maps them to a list of GraphQLErrors.
+     *
+     * Based on the type of the input exception, it delegates to specific methods to generate
+     * appropriate GraphQLError instances. Supported exception types include:
+     * - BusinessException
+     * - NoResourceFoundException
+     * - HttpRequestMethodNotSupportedException
+     * - MethodArgumentNotValidException
+     * - HttpMessageNotReadableException
+     * - Any other unhandled exceptions
+     *
+     * Each exception type is mapped to a corresponding GraphQL error with relevant details like
+     * error message, error type, and custom extensions containing error information.
+     *
+     * @param ex the exception thrown during data fetching
+     * @param env the GraphQL data fetching environment associated with the operation
+     * @return a Mono containing a list of GraphQLErrors representing the resolved exception
+     */
     @Override
     public Mono<List<GraphQLError>> resolveException(Throwable ex, DataFetchingEnvironment env) {
         // 1. 비즈니스 예외

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
@@ -34,7 +34,6 @@ import java.util.Map;
  * @see com.github.hyeonjaez.springcommon.graphql.GraphQLExceptionResolver
  * @since 0.0.2
  */
-// AbstractGraphQLExceptionResolver.java
 public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExceptionResolver {
 
     private static final String STATUS = "status";
@@ -83,8 +82,6 @@ public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExc
         return Mono.just(List.of(handleGenericException(ex, env)));
     }
 
-    // --- Handlers for each exception type ---
-
     /**
      * Handles a {@code BusinessException} and transforms it into a {@code GraphQLError}.
      *
@@ -123,7 +120,6 @@ public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExc
      * @return a {@link GraphQLError} representing the resolved exception
      */
     protected GraphQLError handleNoResourceFound(NoResourceFoundException ex, DataFetchingEnvironment env) {
-        // 예: 404 Not Found
         return GraphqlErrorBuilder.newError(env)
                 .message(ex.getMessage())
                 .errorType(ErrorType.DataFetchingException)
@@ -150,7 +146,7 @@ public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExc
      */
     protected GraphQLError handleMethodNotSupported(HttpRequestMethodNotSupportedException ex, DataFetchingEnvironment env) {
         return GraphqlErrorBuilder.newError(env)
-                .message("지원하지 않는 HTTP 메서드입니다: " + ex.getMethod())
+                .message("Unsupported HTTP method: " + ex.getMethod())
                 .errorType(ErrorType.DataFetchingException)
                 .extensions(Map.of(
                         STATUS, ApiStatus.FAILURE,
@@ -172,7 +168,6 @@ public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExc
      * @return a {@link GraphQLError} representing the validation error with relevant details
      */
     protected GraphQLError handleValidationException(MethodArgumentNotValidException ex, DataFetchingEnvironment env) {
-        // 첫 번째 필드 오류 메시지만 예시로 사용
         var fieldError = ex.getBindingResult().getFieldErrors().get(0);
         return GraphqlErrorBuilder.newError(env)
                 .message(fieldError.getDefaultMessage())
@@ -203,7 +198,7 @@ public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExc
     @SuppressWarnings("unused")
     protected GraphQLError handleMessageNotReadable(HttpMessageNotReadableException ex, DataFetchingEnvironment env) {
         return GraphqlErrorBuilder.newError(env)
-                .message("잘못된 요청 메시지 형식입니다.")
+                .message("Invalid request message format.")
                 .errorType(ErrorType.DataFetchingException)
                 .extensions(Map.of(
                         STATUS, ApiStatus.FAILURE,

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/AbstractGraphQLExceptionResolver.java
@@ -32,14 +32,19 @@ import java.util.Map;
  *
  * @author hansnam1105
  * @see com.github.hyeonjaez.springcommon.graphql.GraphQLExceptionResolver
- * @since 0.0.1
+ * @since 0.0.2
  */
 // AbstractGraphQLExceptionResolver.java
-public abstract class AbstractGraphQLExceptionResolver
-        implements DataFetcherExceptionResolver {
+public abstract class AbstractGraphQLExceptionResolver implements DataFetcherExceptionResolver {
+
+    private static final String STATUS = "status";
+    private static final String STATUS_CODE = "statusCode";
+    private static final String ERROR_CODE = "errorCode";
 
     /**
      * Resolves exceptions occurring during the GraphQL data fetching process and maps them to a list of GraphQLErrors.
+     *
+     * Returns Mono: To comply with Spring for GraphQL's asynchronous and non-blocking interface.
      *
      * Based on the type of the input exception, it delegates to specific methods to generate
      * appropriate GraphQLError instances. Supported exception types include:
@@ -57,37 +62,41 @@ public abstract class AbstractGraphQLExceptionResolver
      * @param env the GraphQL data fetching environment associated with the operation
      * @return a Mono containing a list of GraphQLErrors representing the resolved exception
      */
+
     @Override
     public Mono<List<GraphQLError>> resolveException(Throwable ex, DataFetchingEnvironment env) {
-        // 1. 비즈니스 예외
         if (ex instanceof BusinessException) {
             return Mono.just(List.of(handleBusinessException((BusinessException) ex, env)));
         }
-        // 2. 리소스 미발견
         if (ex instanceof NoResourceFoundException noResourceFoundException) {
             return Mono.just(List.of(handleNoResourceFound(noResourceFoundException, env)));
         }
-        // 3. HTTP 메서드 지원 안 함
         if (ex instanceof HttpRequestMethodNotSupportedException httpRequestMethodNotSupportedException) {
             return Mono.just(List.of(handleMethodNotSupported(httpRequestMethodNotSupportedException, env)));
         }
-        // 4. 검증 실패
         if (ex instanceof MethodArgumentNotValidException methodArgumentNotValidException) {
             return Mono.just(List.of(handleValidationException(methodArgumentNotValidException, env)));
         }
-        // 5. 메시지 컨버팅 실패 (JSON 파싱 오류 등)
         if (ex instanceof HttpMessageNotReadableException httpMessageNotReadableException) {
             return Mono.just(List.of(handleMessageNotReadable(httpMessageNotReadableException, env)));
         }
-        // 6. 그 외 예외 (Internal Server Error)
         return Mono.just(List.of(handleGenericException(ex, env)));
     }
 
     // --- Handlers for each exception type ---
-    private static final String STATUS = "status";
-    private static final String STATUS_CODE = "statusCode";
-    private static final String ERROR_CODE = "errorCode";
 
+    /**
+     * Handles a {@code BusinessException} and transforms it into a {@code GraphQLError}.
+     *
+     * This method retrieves the error code and associated details from the {@code BusinessException},
+     * then constructs a {@code GraphQLError} with an appropriate error message, error type, and
+     * extensions containing additional information about the error. It leverages the
+     * {@code DataFetchingEnvironment} to tie the error with the ongoing GraphQL operation context.
+     *
+     * @param ex the {@link BusinessException} to be handled
+     * @param env the {@link DataFetchingEnvironment} containing the current GraphQL operation's context
+     * @return a {@link GraphQLError} representing the resolved business exception
+     */
     protected GraphQLError handleBusinessException(BusinessException ex, DataFetchingEnvironment env) {
         var code = ex.getErrorCode();
         return GraphqlErrorBuilder.newError(env)
@@ -101,6 +110,18 @@ public abstract class AbstractGraphQLExceptionResolver
                 .build();
     }
 
+    /**
+     * Handles a {@code NoResourceFoundException} by transforming it into a {@code GraphQLError}.
+     *
+     * This method creates a {@code GraphQLError} with the message from the exception, an error type
+     * of {@code DataFetchingException}, and custom extensions containing error details such as status,
+     * status code, and error code. It utilizes the {@code DataFetchingEnvironment} to associate the
+     * error with the current GraphQL operation.
+     *
+     * @param ex the {@link NoResourceFoundException} to be handled
+     * @param env the {@link DataFetchingEnvironment} containing the context of the current GraphQL operation
+     * @return a {@link GraphQLError} representing the resolved exception
+     */
     protected GraphQLError handleNoResourceFound(NoResourceFoundException ex, DataFetchingEnvironment env) {
         // 예: 404 Not Found
         return GraphqlErrorBuilder.newError(env)
@@ -114,6 +135,19 @@ public abstract class AbstractGraphQLExceptionResolver
                 .build();
     }
 
+    /**
+     * Handles an HttpRequestMethodNotSupportedException by transforming it into a GraphQLError.
+     *
+     * This method constructs a GraphQLError with a specific message indicating the unsupported
+     * HTTP method, an error type of DataFetchingException, and additional extensions containing
+     * error details such as status, status code, and error code.
+     *
+     * @param ex the HttpRequestMethodNotSupportedException to be handled, representing
+     *           the unsupported HTTP method during the request
+     * @param env the DataFetchingEnvironment containing context information about the
+     *            current GraphQL request
+     * @return a GraphQLError representing the resolved exception with error details
+     */
     protected GraphQLError handleMethodNotSupported(HttpRequestMethodNotSupportedException ex, DataFetchingEnvironment env) {
         return GraphqlErrorBuilder.newError(env)
                 .message("지원하지 않는 HTTP 메서드입니다: " + ex.getMethod())
@@ -126,6 +160,17 @@ public abstract class AbstractGraphQLExceptionResolver
                 .build();
     }
 
+    /**
+     * Handles a {@code MethodArgumentNotValidException} and transforms it into a {@code GraphQLError}.
+     *
+     * This method extracts the first field error from the exception's binding result to construct a
+     * {@code GraphQLError} with an error type of {@code ValidationError}. The error message and
+     * information about the invalid field are included in the extensions for providing detailed feedback.
+     *
+     * @param ex the {@link MethodArgumentNotValidException} containing validation errors
+     * @param env the {@link DataFetchingEnvironment} providing the context of the current GraphQL operation
+     * @return a {@link GraphQLError} representing the validation error with relevant details
+     */
     protected GraphQLError handleValidationException(MethodArgumentNotValidException ex, DataFetchingEnvironment env) {
         // 첫 번째 필드 오류 메시지만 예시로 사용
         var fieldError = ex.getBindingResult().getFieldErrors().get(0);
@@ -141,6 +186,20 @@ public abstract class AbstractGraphQLExceptionResolver
                 .build();
     }
 
+    /**
+     * Handles a {@code HttpMessageNotReadableException} and transforms it into a {@code GraphQLError}.
+     *
+     * This method constructs a {@code GraphQLError} with a predefined error message indicating
+     * an invalid request message format. It sets the error type as {@code DataFetchingException}
+     * and includes additional error details such as status, status code, and error code in
+     * the extensions map. The {@code DataFetchingEnvironment} is used to associate the error
+     * with the current GraphQL operation context.
+     *
+     * @param ex the {@link HttpMessageNotReadableException} that indicates a failed attempt
+     *           to read the HTTP message
+     * @param env the {@link DataFetchingEnvironment} associated with the current GraphQL operation
+     * @return a {@link GraphQLError} representing the resolved error for an unreadable HTTP message
+     */
     @SuppressWarnings("unused")
     protected GraphQLError handleMessageNotReadable(HttpMessageNotReadableException ex, DataFetchingEnvironment env) {
         return GraphqlErrorBuilder.newError(env)
@@ -154,6 +213,19 @@ public abstract class AbstractGraphQLExceptionResolver
                 .build();
     }
 
+    /**
+     * Handles a generic exception and transforms it into a {@code GraphQLError}.
+     *
+     * This method is used as a fallback for handling exceptions that do not match
+     * specific exception handlers. It creates a {@code GraphQLError} with a
+     * generalized error message, an error type of {@code DataFetchingException},
+     * and includes additional extensions containing error details such as status,
+     * status code, and error code.
+     *
+     * @param ex the throwable or exception to be handled
+     * @param env the {@link DataFetchingEnvironment} associated with the current GraphQL operation
+     * @return a {@link GraphQLError} representing the resolved generic exception
+     */
     @SuppressWarnings("unused")
     protected GraphQLError handleGenericException(Throwable ex, DataFetchingEnvironment env) {
         return GraphqlErrorBuilder.newError(env)

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
@@ -12,8 +12,7 @@ import org.springframework.stereotype.Component;
  *
  * It allows seamless integration of exception handling into a Spring-based application without additional configuration.
  */
-// GraphQLExceptionResolver.java (구현체)
-@Component  // Spring Bean으로 등록
+@Component
 public class GraphQLExceptionResolver extends AbstractGraphQLExceptionResolver {
     /**
      * GraphQLExceptionResolver is the default bean provided to ensure functionality "out-of-the-box"

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
@@ -15,5 +15,15 @@ import org.springframework.stereotype.Component;
 // GraphQLExceptionResolver.java (구현체)
 @Component  // Spring Bean으로 등록
 public class GraphQLExceptionResolver extends AbstractGraphQLExceptionResolver {
-    // No specific implementation - using default behavior
-}
+    /**
+     * GraphQLExceptionResolver is the default bean provided to ensure functionality "out-of-the-box"
+     * when this library is added.
+     *
+     * It is not strictly required; if a user registers their own custom {@code CustomGraphQLExceptionResolver}
+     * bean, that custom implementation will be used instead without any issues.
+     *
+     * However, if *no* such bean is registered by the user at all, the exception handling logic
+     * would not be active. Therefore, this default implementation is included to guarantee
+     * that the exception handling feature is available by default, requiring no additional setup.
+     */
+    }

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
@@ -2,8 +2,18 @@ package com.github.hyeonjaez.springcommon.graphql;
 
 import org.springframework.stereotype.Component;
 
+/**
+ * GraphQLExceptionResolver acts as a Spring Component responsible for handling exceptions
+ * during the GraphQL data fetching process. It extends AbstractGraphQLExceptionResolver
+ * to utilize the default exception handling behavior defined in its parent class.
+ *
+ * This implementation does not override or extend the behavior of AbstractGraphQLExceptionResolver,
+ * but rather serves as a concrete implementation for Spring to inject where needed.
+ *
+ * It allows seamless integration of exception handling into a Spring-based application without additional configuration.
+ */
 // GraphQLExceptionResolver.java (구현체)
 @Component  // Spring Bean으로 등록
 public class GraphQLExceptionResolver extends AbstractGraphQLExceptionResolver {
-    // 특별한 구현 없음 - 기본 동작 사용
+    // No specific implementation - using default behavior
 }

--- a/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
+++ b/src/main/java/com/github/hyeonjaez/springcommon/graphql/GraphQLExceptionResolver.java
@@ -1,0 +1,9 @@
+package com.github.hyeonjaez.springcommon.graphql;
+
+import org.springframework.stereotype.Component;
+
+// GraphQLExceptionResolver.java (구현체)
+@Component  // Spring Bean으로 등록
+public class GraphQLExceptionResolver extends AbstractGraphQLExceptionResolver {
+    // 특별한 구현 없음 - 기본 동작 사용
+}

--- a/src/test/java/com/github/hyeonjaez/springcommon/graphql/error/GraphQLExceptionResolverIntegrationTest.java
+++ b/src/test/java/com/github/hyeonjaez/springcommon/graphql/error/GraphQLExceptionResolverIntegrationTest.java
@@ -1,0 +1,218 @@
+package com.github.hyeonjaez.springcommon.graphql.error;
+
+import com.github.hyeonjaez.springcommon.exception.BusinessException;
+import com.github.hyeonjaez.springcommon.exception.CommonErrorCode;
+import com.github.hyeonjaez.springcommon.graphql.AbstractGraphQLExceptionResolver;
+import com.github.hyeonjaez.springcommon.graphql.GraphQLExceptionResolver;
+import com.github.hyeonjaez.springcommon.response.ApiStatus;
+import graphql.GraphQLError;
+import graphql.Scalars;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.MergedField;
+import graphql.execution.ResultPath;
+import graphql.language.Field;
+import graphql.language.SourceLocation;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.GraphQLFieldDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GraphQLExceptionResolverTest {
+
+    private AbstractGraphQLExceptionResolver resolver;
+    private DataFetchingEnvironment env;
+
+    /**
+     * Sets up the test environment for the test cases in the GraphQLExceptionResolverTest class.
+     *
+     * This method initializes the necessary objects and state required for testing the
+     * behavior of the GraphQLExceptionResolver. The setup includes the following steps:
+     *
+     * 1. Creates a GraphQLFieldDefinition named "dummy" with the type Scalars.GraphQLString.
+     * 2. Creates an AST Field object representing the "dummy" field, with a source location
+     *    specified at line 1 and column 1.
+     * 3. Constructs a MergedField object that includes the AST Field instance.
+     * 4. Builds an ExecutionStepInfo object representing the execution context for the
+     *    "dummy" field. This includes the path ["dummy"], the field definition, and the type.
+     * 5. Instantiates a DataFetchingEnvironment with the merged field and execution step
+     *    information.
+     *
+     * The initialized objects include:
+     * - `resolver`: An instance of GraphQLExceptionResolver to be tested.
+     * - `env`: A configured DataFetchingEnvironment instance that simulates the GraphQL
+     *          execution context for the tests.
+     *
+     * This method is annotated with @BeforeEach, ensuring it is executed before each test
+     * method in the GraphQLExceptionResolverTest class.
+     */
+    @BeforeEach
+    void setUp() {
+        resolver = new GraphQLExceptionResolver();
+
+        // 1) GraphQLFieldDefinition
+        GraphQLFieldDefinition fd = GraphQLFieldDefinition.newFieldDefinition()
+                .name("dummy")
+                .type(Scalars.GraphQLString)
+                .build();
+
+        // 2) AST Field with SourceLocation
+        Field astField = Field.newField("dummy")
+                .sourceLocation(new SourceLocation(1, 1))
+                .build();
+
+        // 3) MergedField
+        MergedField mergedField = MergedField.newMergedField()
+                .addField(astField)
+                .build();
+
+        // 4) ExecutionStepInfo with path ["dummy"]
+        ResultPath path = ResultPath.rootPath().segment("dummy");
+        ExecutionStepInfo info = ExecutionStepInfo.newExecutionStepInfo()
+                .path(path)
+                .type(Scalars.GraphQLString)
+                .fieldDefinition(fd)
+                .build();
+
+        // 5) Build DataFetchingEnvironment with mergedField and executionInfo
+        env = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                .mergedField(mergedField)
+                .executionStepInfo(info)
+                .build();
+    }
+
+    @Test
+    void handleBusinessException() {
+        BusinessException ex = new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
+        List<GraphQLError> errors = resolver.resolveException(ex, env).block();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        GraphQLError error = errors.get(0);
+
+        assertEquals(CommonErrorCode.INVALID_INPUT_VALUE.getMessage(), error.getMessage());
+        Map<String, Object> ext = error.getExtensions();
+        assertEquals(ApiStatus.FAILURE, ext.get("status"));
+        assertEquals(CommonErrorCode.INVALID_INPUT_VALUE.getHttpStatus().value(), ext.get("statusCode"));
+        assertEquals(CommonErrorCode.INVALID_INPUT_VALUE.getCode(), ext.get("errorCode"));
+    }
+
+    @Test
+    void handleNoResourceFoundException() {
+        NoResourceFoundException ex = new NoResourceFoundException(HttpMethod.GET, "/test");
+        List<GraphQLError> errors = resolver.resolveException(ex, env).block();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        GraphQLError error = errors.get(0);
+
+        assertEquals(ex.getMessage(), error.getMessage());
+        Map<String, Object> ext = error.getExtensions();
+        assertEquals(ApiStatus.FAILURE, ext.get("status"));
+        assertEquals(404, ext.get("statusCode"));
+        assertEquals("RESOURCE_NOT_FOUND", ext.get("errorCode"));
+    }
+
+    @Test
+    void handleHttpRequestMethodNotSupportedException() {
+        HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("POST");
+        List<GraphQLError> errors = resolver.resolveException(ex, env).block();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        GraphQLError error = errors.get(0);
+
+        assertTrue(error.getMessage().contains("지원하지 않는 HTTP 메서드"));
+        Map<String, Object> ext = error.getExtensions();
+        assertEquals(ApiStatus.FAILURE, ext.get("status"));
+        assertEquals(405, ext.get("statusCode"));
+        assertEquals("METHOD_NOT_ALLOWED", ext.get("errorCode"));
+    }
+
+    /**
+     * Tests the handling of a `MethodArgumentNotValidException` thrown due to invalid method argument constraints.
+     *
+     * The test verifies the following behavior:
+     * 1. Constructs an invalid method parameter using the `Dummy` class with a validation error.
+     * 2. Simulates the exception `MethodArgumentNotValidException` using a mocked `BindingResult`.
+     * 3. Uses the `resolver` to process the exception and map it to a list of `GraphQLError` results.
+     *
+     * Assertions:
+     * - Verifies that the list of errors is not null and contains exactly one error.
+     * - Ensures the error message is consistent with the validation error details.
+     * - Verifies the custom extensions in the `GraphQLError` object, including:
+     *   - `status` indicating the API failure status.
+     *   - `statusCode` confirming the HTTP status code (400 in this case).
+     *   - `errorCode` identifying the specific error type (`INVALID_ARGUMENT`).
+     *   - `field` indicating the invalid parameter name.
+     *
+     * Note:
+     * This test checks how validation errors are properly encapsulated and surfaced via GraphQL error responses.
+     *
+     * @throws NoSuchMethodException if the method being tested does not exist
+     */
+    @Test
+    void handleMethodArgumentNotValidException() throws NoSuchMethodException {
+        class Dummy { public void dummy(@SuppressWarnings("unused") String param) {} }
+        Method method = Dummy.class.getMethod("dummy", String.class);
+        MethodParameter methodParam = new MethodParameter(method, 0);
+        Dummy target = new Dummy();
+        BindingResult bindingResult = new BeanPropertyBindingResult(target, "dummy");
+        bindingResult.addError(new FieldError("dummy", "param", "must not be blank"));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(methodParam, bindingResult);
+
+        List<GraphQLError> errors = resolver.resolveException(ex, env).block();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        GraphQLError error = errors.get(0);
+
+        assertEquals("must not be blank", error.getMessage());
+        Map<String, Object> ext = error.getExtensions();
+        assertEquals(ApiStatus.FAILURE, ext.get("status"));
+        assertEquals(400, ext.get("statusCode"));
+        assertEquals("INVALID_ARGUMENT", ext.get("errorCode"));
+        assertEquals("param", ext.get("field"));
+    }
+
+    @Test
+    void handleHttpMessageNotReadableException() {
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("JSON parse error");
+        List<GraphQLError> errors = resolver.resolveException(ex, env).block();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        GraphQLError error = errors.get(0);
+
+        assertEquals("잘못된 요청 메시지 형식입니다.", error.getMessage());
+        Map<String, Object> ext = error.getExtensions();
+        assertEquals(ApiStatus.FAILURE, ext.get("status"));
+        assertEquals(400, ext.get("statusCode"));
+        assertEquals("MESSAGE_NOT_READABLE", ext.get("errorCode"));
+    }
+
+    @Test
+    void handleGenericException() {
+        Exception ex = new Exception("boom");
+        List<GraphQLError> errors = resolver.resolveException(ex, env).block();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        GraphQLError error = errors.get(0);
+
+        assertEquals("Internal server error", error.getMessage());
+        Map<String, Object> ext = error.getExtensions();
+        assertEquals(ApiStatus.FAILURE, ext.get("status"));
+        assertEquals(500, ext.get("statusCode"));
+        assertEquals("INTERNAL_ERROR", ext.get("errorCode"));
+    }
+}

--- a/src/test/java/com/github/hyeonjaez/springcommon/graphql/error/GraphQLExceptionResolverIntegrationTest.java
+++ b/src/test/java/com/github/hyeonjaez/springcommon/graphql/error/GraphQLExceptionResolverIntegrationTest.java
@@ -134,7 +134,7 @@ class GraphQLExceptionResolverTest {
         assertEquals(1, errors.size());
         GraphQLError error = errors.get(0);
 
-        assertTrue(error.getMessage().contains("지원하지 않는 HTTP 메서드"));
+        assertTrue(error.getMessage().contains("Unsupported HTTP method"));
         Map<String, Object> ext = error.getExtensions();
         assertEquals(ApiStatus.FAILURE, ext.get("status"));
         assertEquals(405, ext.get("statusCode"));
@@ -194,7 +194,7 @@ class GraphQLExceptionResolverTest {
         assertEquals(1, errors.size());
         GraphQLError error = errors.get(0);
 
-        assertEquals("잘못된 요청 메시지 형식입니다.", error.getMessage());
+        assertEquals("Invalid request message format.", error.getMessage());
         Map<String, Object> ext = error.getExtensions();
         assertEquals(ApiStatus.FAILURE, ext.get("status"));
         assertEquals(400, ext.get("statusCode"));

--- a/src/test/resources/schema.graphqls
+++ b/src/test/resources/schema.graphqls
@@ -1,0 +1,4 @@
+type Query {
+    throwBusinessError: String
+    throwRuntimeError: String
+}


### PR DESCRIPTION
## 📌 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
GraphQL API 전용 전역 예외 처리 모듈을 추가합니다.  
- `spring-api-common-graphql` 모듈을 생성하여 기존 REST 전역 예외 처리기(`AbstractGlobalExceptionHandler`)와 동일한 예외 타입을 GraphQL 환경에서도 처리하도록 `AbstractGraphQLExceptionResolver`를 구현했습니다.  
- 각 예외별 핸들러 메서드를 통해 `extensions` 필드에 `status`, `statusCode`, `errorCode` 등을 포함한 일관된 오류 응답을 제공합니다.  
- GraphQL 스타터(`spring-boot-starter-graphql`) 의존성을 추가하고, README에 설치 및 사용법 가이드를 업데이트했습니다.  


<!-- Resolves: #(Issue Number) -->

---

## 📂 PR 유형
어떤 변경 사항이 있나요?

- [X] ✨ 새로운 기능 추가
- [ ] 🐞 버그 수정
- [ ] 💄 CSS 등 사용자 UI 디자인 변경
- [ ] 🧹 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] ♻️ 코드 리팩토링
- [ ] 💬 주석 추가 및 수정
- [X] 📝 문서 수정
- [X] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 📦 빌드 부분 혹은 패키지 매니저 수정
- [ ] 🗂️ 파일 혹은 폴더명 수정
- [ ] 🗑️ 파일 혹은 폴더 삭제

---

## 📋 상세 내용
- **모듈 생성**  
  - `spring-api-common-graphql` 서브 모듈 추가  
  - `pom.xml` / `build.gradle`에 `org.springframework.boot:spring-boot-starter-graphql` 의존성 등록  
- **예외 처리기 구현** (`graphql` 패키지)  
  - `AbstractGraphQLExceptionResolver`  
    - `BusinessException`, `NoResourceFoundException` 등 요청하신 5개 예외 타입 분기 처리  
    - 각 예외별 핸들러(`handleBusinessException`, `handleNoResourceFound`, ...) 구현  
    - `GraphqlErrorBuilder` 사용해 `extensions` 필드에 `status`, `statusCode`, `errorCode` 포함  
  - `GraphQLExceptionResolver`  
    - `@Component`로 등록하여 Spring Boot GraphQL 전역 예외 처리기에 자동 연동  
- **README 수정**  
  - Installation 섹션에 GraphQL 모듈 의존성 가이드 추가  
  - Features, Package Structure, Usage 섹션에 GraphQL 전역 예외 처리 지원 항목 및 예시 코드/응답 추가  

---

## 🖥️ 테스트 방법
1. 샘플 Spring Boot 애플리케이션에 `spring-api-common-graphql` 의존성 추가  
2. GraphQL 스키마에 간단한 쿼리/뮤테이션 정의  
3. 서비스 로직에서 `BusinessException` 등 지정 예외를 던지는 Resolver 작성  
```
@QueryMapping
public UserDto getUserById(@Argument Long id) {
    UserDto user = userService.findById(id);
    if (user == null) {
        throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
    }
    return user;
}
```

4. 다음 GraphQL 요청을 통해 응답 오류를 확인  
```
{
  "errors": [
    {
      "message": "User not found",          // UserErrorCode.USER_NOT_FOUND.getMessage()
      "extensions": {
        "status": "FAILURE",                // ApiStatus.FAILURE
        "statusCode": 404,                  // UserErrorCode.USER_NOT_FOUND.getHttpStatus().value()
        "errorCode": "USER-001"             // UserErrorCode.USER_NOT_FOUND.getCode()
        // + 커스텀 필드를 추가했다면 여기에 포함됩니다.
      }
    }
  ],
  "data": {
    "getUserById": null
  }
}
```
5. 만약 예외 처리 로직 커스터마이징 필요시 `CustomGraphQLExceptionResolver` 등록해서 커스텀 빈이 자동으로 등록되어 동작
```
@Component
public class CustomGraphQLExceptionResolver 
        extends AbstractGraphQLExceptionResolver {
...
}
```
